### PR TITLE
Use rc for default config values

### DIFF
--- a/.artilleryrc
+++ b/.artilleryrc
@@ -1,0 +1,3 @@
+{
+  "output": "artillery_report.json"
+}

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Where `hello.json` is your tests script that contains something like:
 }
 ```
 
+You can specify config default values using a `.artilleryrc` file on your home folder or in any other [location supported by `rc`](https://github.com/dominictarr/rc#standards). Have a look at the included `.artilleryrc` for an example.
+
 # Create a report
 
 Create a graphical report from the JSON stats produced by `artillery run` with:

--- a/lib/commands/quick.js
+++ b/lib/commands/quick.js
@@ -3,6 +3,8 @@
 const run = require('./run');
 const parse = require('url').parse;
 const fs = require('fs');
+const _ = require('lodash');
+const defaultOptions = require('rc')('artillery');
 
 module.exports = quick;
 
@@ -22,6 +24,8 @@ function quick(url, options) {
       }
     ]
   };
+
+  options = _.defaultsDeep(options, defaultOptions);
 
   let p = parse(url);
   let target = p.protocol + '//' + p.host;

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -10,10 +10,13 @@ const csv = require('csv-parse');
 const util = require('util');
 const cli = require('cli');
 const YAML = require('yamljs');
+const defaultOptions = require('rc')('artillery');
 
 module.exports = run;
 
 function run(scriptPath, options) {
+
+  options = _.defaultsDeep(options, defaultOptions);
 
   let logfile =
     'artillery_report_' +

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "lodash": "^3.9.1",
     "artillery-core": "latest",
     "open": "0.0.5",
+    "rc": "^1.1.6",
     "yamljs": "^0.2.4"
   },
   "devDependencies": {

--- a/test/test.sh
+++ b/test/test.sh
@@ -44,3 +44,13 @@ function artillery() {
   ./bin/artillery run ./test/scripts/multiple_payloads.json | grep 'all scenarios completed'
   [ $? -eq 0 ]
 }
+
+@test "Run a script using default options (output)" {
+  ./bin/artillery run ./test/scripts/hello.json | grep 'Log file: artillery_report.json'
+  [ $? -eq 0 ]
+}
+
+@test "Run a script overwriting default options (output)" {
+  ./bin/artillery run ./test/scripts/hello.json -o artillery_report_custom | grep 'Log file: artillery_report_custom.json'
+  [ $? -eq 0 ]
+}


### PR DESCRIPTION
This allows you to specify config default values for the `run` command using a `.minigunrc` file on your home folder or in any other [location supported by `rc`](https://github.com/dominictarr/rc#standards). 

The included `.minigunrc` serves as an example and is used for the test as well.

Let me know what you think :)