### PR TITLE
Invalid file message is now adjusted to the file format.

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -52,15 +52,17 @@ function run(scriptPath, options) {
         }
 
         let script;
+        let fileformat;
         try {
           if (/\.ya?ml$/.test(path.extname(scriptPath))) {
+            fileformat = 'YAML';
             script = YAML.parse(data);
           } else {
+            fileformat = 'JSON';
             script = JSON.parse(data);
           }
         } catch (e) {
-          const msg2 = util.format(
-            'File %s does not appear to be valid JSON', scriptPath);
+          const msg2 = `File ${scriptPath} does not appear to be valid ${fileformat}`;
           return callback(new Error(msg2), null);
         }
 


### PR DESCRIPTION
Invalid file format message was always complaining about JSON even if the file was YAML.