### PR TITLE
quick mode improvements

### DIFF
--- a/bin/artillery
+++ b/bin/artillery
@@ -27,8 +27,10 @@ program
 program
   .command('quick <url>')
   .description('Run a quick test without writing a test script')
-  .option('-d, --duration <seconds>', 'Duration of the test')
-  .option('-r, --rate <number>', 'Arrivals per second')
+  .option('-r, --rate <number>', 'New arrivals per second')
+  .option('-c, --count <number>', 'Fixed number of arrivals')
+  .option('-d, --duration <seconds>', 'Duration of the arrival phase')
+  .option('-n <number>', 'Number of requests each new arrival will send')
   .option('-p, --payload <string>', 'Set POST payload')
   .option('-t, --content-type <string>',
           'Set content-type (defaults to application/json)')

--- a/lib/commands/quick.js
+++ b/lib/commands/quick.js
@@ -10,6 +10,7 @@ const fs = require('fs');
 const _ = require('lodash');
 const defaultOptions = require('rc')('artillery');
 const tmp = require('tmp');
+const debug = require('debug')('commands:quick');
 
 module.exports = quick;
 
@@ -36,16 +37,31 @@ function quick(url, options) {
   let target = p.protocol + '//' + p.host;
   script.config.target = target;
 
+  if (options.c && options.r) {
+    console.log('Error: either fixed concurrency or arrivals per second should be set, not both');
+    process.exit(1);
+  }
+
   if (options.insecure && p.protocol.match(/https/)) {
     script.config.tls = {
       rejectUnauthorized: false
     };
   }
 
-  script.config.phases.push({
-    duration: options.duration || 60,
-    arrivalRate: options.rate || 20
-  });
+  if (options.r) {
+    script.config.phases.push({
+      duration: options.duration || 60,
+      arrivalRate: options.rate || 20
+    });
+  } else if (options.c) {
+    script.config.phases.push({
+      duration: options.d * 1000 || Math.ceil(options.c / 50),
+      arrivalCount: options.c || 1
+    });
+  } else {
+    console.log('Error: either arrival rate or fixed concurrency must be specified');
+    process.exit(1);
+  }
 
   let requestSpec = {};
   if (options.payload && p.protocol.match(/http/)) {
@@ -63,6 +79,15 @@ function quick(url, options) {
   } else {
     throw new Error('Unknown protocol');
   }
+
+  if (options.n) {
+    requestSpec = {
+      loop: [ requestSpec ],
+      count: options.n
+    };
+  }
+
+  debug('requestSpec: %s', JSON.stringify(requestSpec, null, 2));
 
   script.scenarios[0].flow.push(requestSpec);
   if (p.protocol.match(/ws/)) {

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -23,7 +23,7 @@ module.exports = run;
 function run(scriptPath, options) {
 
   let logfile;
-  if (options.output) {
+  if (options.output && options.output !== defaultOptions.output) {
     logfile = options.output;
     if (!logfile.match(/\.json$/)) {
       logfile += '.json';
@@ -142,7 +142,7 @@ function run(scriptPath, options) {
       let usesXPathCapture = false;
       context.script.scenarios.forEach(function(scenario) {
         scenario.flow.forEach(function(step) {
-          let params  = step[_.keys(step)[0]];
+          let params = step[_.keys(step)[0]];
           if ((params.capture && params.capture.xpath) ||
               (params.match && params.match.xpath)) {
             usesXPathCapture = true;

--- a/package.json
+++ b/package.json
@@ -39,13 +39,14 @@
     "email": "npm@veldstra.org"
   },
   "dependencies": {
+    "arrivals": "^2.0.2",
     "artillery-core": "1.6.2",
     "async": "^1.0.0",
     "chalk": "1.1.3",
     "cli": "^0.6.6",
     "commander": "^2.8.1",
     "csv-parse": "^0.1.1",
-    "debug": "^2.2.0",
+    "debug": "2.2.0",
     "lodash": "^3.9.1",
     "moment": "2.11.2",
     "open": "0.0.5",

--- a/test/test.sh
+++ b/test/test.sh
@@ -85,3 +85,23 @@ function artillery() {
     npm install artillery-xml-capture
     [ $grep_status -eq 0 ]
 }
+
+@test "Quick: does not accept invalid combination of options" {
+
+    set +e
+    ./bin/artillery quick -c 10 -r 10 -n 50 https://artillery.io
+    status1=$?
+    ./bin/artillery quick -d 60 -n 50 https://artillery.io
+    status2=$?
+    set -e
+
+    [[ $status1 -eq 1 && $status2 -eq 1 ]]
+}
+
+@test "Quick: specified number of requests is sent on each connection" {
+    ./bin/artillery quick -c 200 -n 5 -o report.json http://localhost:3003/
+    requestCount=$(jq .aggregate.requestsCompleted report.json)
+    rm report.json
+
+    [[ $requestCount -eq 1000 ]]
+}


### PR DESCRIPTION
This PR improves `artillery quick`:

- add "-c" flag to specify a fixed number of arrivals
- add "-n" flag to specify the number of messages to send