### PR TITLE
Fix quick mode - need a longhand variant for "-n"

### DIFF
--- a/bin/artillery
+++ b/bin/artillery
@@ -30,7 +30,7 @@ program
   .option('-r, --rate <number>', 'New arrivals per second')
   .option('-c, --count <number>', 'Fixed number of arrivals')
   .option('-d, --duration <seconds>', 'Duration of the arrival phase')
-  .option('-n <number>', 'Number of requests each new arrival will send')
+  .option('-n, --num <number>', 'Number of requests each new arrival will send')
   .option('-p, --payload <string>', 'Set POST payload')
   .option('-t, --content-type <string>',
           'Set content-type (defaults to application/json)')

--- a/lib/commands/quick.js
+++ b/lib/commands/quick.js
@@ -84,10 +84,10 @@ function quick(url, options) {
     throw new Error('Unknown protocol');
   }
 
-  if (options.n) {
+  if (options.num) {
     requestSpec = {
       loop: [requestSpec],
-      count: options.n
+      count: options.num
     };
   }
 

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -333,7 +333,7 @@ function humanize(report, opts) {
   if (opts.showScenarioCounts && report.scenarioCounts) {
     console.log('  Scenario counts:');
     _.each(report.scenarioCounts, function(count, name) {
-      let percentage = Math.round(count / report.aggregate.scenariosCompleted * 100 * 1000) / 1000;
+      let percentage = Math.round(count / report.scenariosCompleted * 100 * 1000) / 1000;
       console.log('    %s: %s (%s\%)', name, count, percentage);
     });
   }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "async": "^1.0.0",
     "chalk": "1.1.3",
     "cli": "^0.6.6",
-    "commander": "^2.8.1",
+    "commander": "2.9.0",
     "csv-parse": "^0.1.1",
     "debug": "2.2.0",
     "lodash": "^3.9.1",

--- a/test/test.sh
+++ b/test/test.sh
@@ -104,9 +104,9 @@ function artillery() {
 }
 
 @test "Quick: specified number of requests is sent on each connection" {
-    artillery quick -c 200 -n 5 -o report.json http://localhost:3003/
+    artillery quick -c 25 -n 5 -o report.json http://localhost:3003/
     requestCount=$(jq .aggregate.requestsCompleted report.json)
     rm report.json
 
-    [[ $requestCount -eq 1000 ]]
+    [[ $requestCount -eq 125 ]]
 }


### PR DESCRIPTION
"-n" not always defined unless there's a longhand alternative. This
seems to be an (intermittent?) issue in Commander:

https://github.com/tj/commander.js/issues/541