### PR TITLE
bugfix numWorkers

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -47,7 +47,7 @@ Runner.prototype.run = function run() {
   //
   // Create worker scripts (distribute the work):
   //
-  let numWorkers = process.env.ARTILLERY_WORKERS || 1 || os.cpus().length;
+  let numWorkers = process.env.ARTILLERY_WORKERS || os.cpus().length || 1;
   let workerScripts = divideWork(this._script, numWorkers);
   // Overwrite statsInterval for workers:
   L.each(workerScripts, function(s) {


### PR DESCRIPTION
`let numWorkers = process.env.ARTILLERY_WORKERS || 1 || os.cpus().length;`
has always the number of workers = 1. 
after exchage ` os.cpus().length || 1;` contains `numWorkers` the number of cores.