### PR TITLE
Report percentage by scenarios created not completed

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -366,7 +366,7 @@ function printReport(report, opts) {
   if (opts.showScenarioCounts && report.scenarioCounts) {
     console.log('  Scenario counts:');
     _.each(report.scenarioCounts, function(count, name) {
-      let percentage = Math.round(count / report.scenariosCompleted * 100 * 1000) / 1000;
+      let percentage = Math.round(count / report.scenariosCreated * 100 * 1000) / 1000;
       console.log('    %s: %s (%s\%)', name, count, percentage);
     });
   }

--- a/lib/report/index.html.ejs
+++ b/lib/report/index.html.ejs
@@ -257,7 +257,7 @@ if(l.size(Report.phases) > 0) {
 if (l.size(Report.aggregate.scenarioCounts) > 0) {
   l.each(Report.aggregate.scenarioCounts, function(count, name) {
     var $tdName = $('<td>' + name + '</td>');
-    var percentage = Math.round(count / Report.aggregate.scenariosCompleted * 100 * 1000) / 1000;
+    var percentage = Math.round(count / Report.aggregate.scenariosCreated * 100 * 1000) / 1000;
     var $tdCount = $('<td>' + count + ' (' + percentage + '%)' + '</td>');
     var $el = $('<tr></tr>')
       .append($tdName)

--- a/test/test.sh
+++ b/test/test.sh
@@ -48,7 +48,7 @@
   [ $? -eq 0 ]
 }
 
-@test "'artilery quick' accepts a variety of options" {
+@test "'artillery quick' accepts a variety of options" {
     ./bin/artillery quick --duration 10 --rate 1 https://artillery.io/
     [ $? -eq 0 ]
 }


### PR DESCRIPTION
Hey Hassy,

When a report is run for a test that produces some number of errors, the percentages shown for different flows start to look a little weird:

![image](https://cloud.githubusercontent.com/assets/1994486/23047678/55980c2c-f47f-11e6-9311-c86f27c6858c.png)

I think the percentages should be derived from all scenarios created, not just those completed, which should make the percentages add back up to 100%.

What do you think?
