### PR TITLE
Fix: shutdown when a worker process terminates unexpectedly

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -49,6 +49,7 @@ Runner.prototype.run = function run() {
   //
   // Create worker scripts (distribute the work):
   //
+  let self = this;
   let numWorkers = process.env.ARTILLERY_WORKERS || 1 || os.cpus().length;
   let workerScripts = divideWork(this._script, numWorkers);
   // Overwrite statsInterval for workers:
@@ -83,8 +84,16 @@ Runner.prototype.run = function run() {
     }
     workerProcess.on('message', this._onWorkerMessage.bind(this));
     workerProcess.once('exit', () => {
-      debug(`worker ${workerProcess.pid} exited`);
-      this._workers[workerProcess.pid].isDone = true;
+      if (!this._workers[workerProcess.pid].isDone) {
+        debug(`worker ${workerProcess.pid} terminated prematurely`);
+        this._workers[workerProcess.pid].isDone = true;
+        console.log('Unexpected error, Artillery shutting down.');
+        self.shutdown(function() {
+          process.exit(1);
+        });
+      } else {
+        debug(`worker ${workerProcess.pid} exited`);
+      }
     });
     workerProcess.send({
       command: 'run',

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -55,7 +55,7 @@ function onError(err) {
 }
 
 function panic(err) {
-  console.error(err);
+  console.log(err);
   process.exit(1);
 }
 


### PR DESCRIPTION
When a worker terminates unexpectedly, we should not continue.

Also a possible cause of: https://github.com/shoreditch-ops/artillery/issues/238