### PR TITLE
Adds the URL to terminal output

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -272,7 +272,14 @@ For more details see: https://github.com/nodejs/node/issues/9756
         log('Report for the previous %ss @ %s',
             result.script.config.statsInterval,
             report.timestamp);
-        printReport(report, {target: result.script.config.target});
+
+        let target = result.script.config.target;
+        if (options.environment) {
+          const environments = result.script.config.environments;
+          target = environments[options.environment].target;
+        }
+
+        printReport(report, {target: target});
         spinnerOn();
       });
 
@@ -284,8 +291,14 @@ For more details see: https://github.com/nodejs/node/issues/9756
         spinnerOff();
         log('all scenarios completed');
         log('Complete report @ %s', report.timestamp);
-        printReport(report,
-          { showScenarioCounts: true, target: result.script.config.target});
+
+        let target = result.script.config.target;
+        if (options.environment) {
+          const environments = result.script.config.environments;
+          target = environments[options.environment].target;
+        }
+
+        printReport(report, { showScenarioCounts: true, target: target});
         report.phases = _.get(result, 'script.config.phases', []);
         delete report.latencies;
 

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -272,7 +272,7 @@ For more details see: https://github.com/nodejs/node/issues/9756
         log('Report for the previous %ss @ %s',
             result.script.config.statsInterval,
             report.timestamp);
-        printReport(report);
+        printReport(report, {target: result.script.config.target});
         spinnerOn();
       });
 
@@ -284,7 +284,8 @@ For more details see: https://github.com/nodejs/node/issues/9756
         spinnerOff();
         log('all scenarios completed');
         log('Complete report @ %s', report.timestamp);
-        printReport(report, { showScenarioCounts: true });
+        printReport(report,
+          { showScenarioCounts: true, target: result.script.config.target});
         report.phases = _.get(result, 'script.config.phases', []);
         delete report.latencies;
 
@@ -337,6 +338,10 @@ For more details see: https://github.com/nodejs/node/issues/9756
 
 function printReport(report, opts) {
   opts = opts || {};
+
+  if (opts.target) {
+    console.log('  Target URL:  %s', opts.target);
+  }
 
   console.log('  Scenarios launched:  %s', report.scenariosCreated);
   console.log('  Scenarios completed: %s', report.scenariosCompleted);


### PR DESCRIPTION
Solves https://github.com/shoreditch-ops/artillery/issues/221 by adding the URL as an option when calling printReport. 

This does **not** add the url to the report itself, just to the print.

Question: why is the URL not in the report itself?