### PR TITLE
add callback to `run`

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -23,7 +23,7 @@ const createRunner = require('../runner');
 
 module.exports = run;
 
-function run(scriptPath, options) {
+function run(scriptPath, options, runCallback) {
   let logfile;
 
   // is the destination a directory that exists?
@@ -309,6 +309,10 @@ For more details see: https://github.com/nodejs/node/issues/9756
               }
             }
           });
+        }
+
+        if (runCallback) {
+          runCallback();
         }
       });
 


### PR DESCRIPTION
Option to provide callback when running `artillery` from another library.

In our case, we're generating `artillery` configuration automatically and when calling `run` require a basic `callback` mechanism to know that testing completed.