### PR TITLE
Refactor: break up run() into several functions

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -56,183 +56,25 @@ function run(scriptPath, options) {
   }
 
   async.waterfall([
-    function readScript(callback) {
-
-      fs.readFile(scriptPath, 'utf-8', function(err, data) {
-
-        if (err) {
-          const msg = util.format('File not found: %s', scriptPath);
-          return callback(new Error(msg), null);
-        }
-
-        let script;
-        let fileformat;
-        try {
-          if (/\.ya?ml$/.test(path.extname(scriptPath))) {
-            fileformat = 'YAML';
-            script = YAML.load(data);
-          } else {
-            fileformat = 'JSON';
-            script = JSON.parse(data);
-          }
-        } catch (e) {
-          const msg2 = `File ${scriptPath} does not appear to be valid ${fileformat}: (${e.message})`;
-          return callback(new Error(msg2), null);
-        }
-
-        if (options.target && script.config) {
-          script.config.target = options.target;
-        }
-
-        if (!script.config.target && !options.environment) {
-          const msg4 = 'No target specified and no environment chosen';
-          return callback(new Error(msg4), null);
-        }
-
-        let validation = validate(script);
-        if (!validation.valid) {
-          log(validation.errors);
-          return callback(new Error('Test script validation error'), null);
-        }
-
-        return callback(null, {script: script});
-      });
+    async.constant(scriptPath),
+    readScript,
+    parseScript,
+    checkTimersBug,
+    checkIfXPathIsUsed,
+    function(script, callback) {
+      return callback(null, script, scriptPath, options);
     },
-    function readPayload(context, callback) {
-
-      if (context.script.config.payload && _.isArray(context.script.config.payload)) {
-        async.map(context.script.config.payload,
-          function(item, callback2) {
-            let absoluteScriptPath = path.resolve(process.cwd(), scriptPath);
-            let payloadFile = path.resolve(path.dirname(absoluteScriptPath), item.path);
-
-            let data = fs.readFileSync(payloadFile, 'utf-8');
-            csv(data, function(err, parsedData) {
-              item.data = parsedData;
-              return callback2(err, item);
-            });
-          },
-          function(err, results) {
-            if (err) {
-              return callback(err, null);
-            }
-            context.payload = results;
-            return callback(null, context);
-          });
-      } else if (context.script.config.payload &&
-                 (_.isObject(context.script.config.payload) ||
-                 options.payload)) {
-
-        //use config if path set else use command line
-        let csvdata;
-        if (context.script.config.payload.path) {
-          let absoluteScriptPath = path.resolve(process.cwd(), scriptPath);
-          let payloadFile = path.resolve(path.dirname(absoluteScriptPath), context.script.config.payload.path);
-          csvdata = fs.readFileSync(payloadFile, 'utf-8');
-        } else {
-          csvdata = fs.readFileSync(options.payload, 'utf-8');
-        }
-        csv(csvdata, function(err, payload) {
-
-          if (err) {
-            const msg3 = util.format(
-              'File %s does not appear to be valid CSV', options.payload);
-            return callback(new Error(msg3), null);
-          }
-
-          context.payload = payload;
-
-          return callback(null, context);
-        });
-      } else {
-        if (context.script.config.payload) {
-          log(
-            'WARNING: payload file not set, but payload is configured in %s\n',
-            scriptPath);
-        }
-
-        return callback(null, context);
-      }
-    },
-    function checkTimersBug(context, callback) {
-      // Node.js versions 6.8.1 - 7.2.0 have a bug which can cause the process
-      // to hang when rampTo is used.
-      // Ref: https://github.com/shoreditch-ops/artillery/issues/210
-
-      // 6.8.1 and 7.0.0 and 7.2.0 but NOT 6.8.0
-      let nv = process.version;
-      let mj = parseInt(nv.substring(1, 2), 10);
-      let mn = parseInt(nv.substring(3, 4), 10);
-      let pt = parseInt(nv.substring(5, 6), 10);
-      if (mj === 7 && mn < 3 ||
-          (mj === 6 && mn > 8) ||
-          (mj === 6 && mn === 8 && pt > 0)) {
-        let usesRampTo = _.some(context.script.config.phases, function(phase) {
-          return !(_.isUndefined(phase.rampTo));
-        });
-
-        if (usesRampTo) {
-          console.error(chalk.bold.red(`
-You are running Node.js ${nv} which is affected by a bug that can cause
-Artillery to hang indefinitely when a rampTo arrival phase is used.
-
-Use Node.js v6.8.0 or lower to avoid the issue.
-
-For more details see: https://github.com/nodejs/node/issues/9756
-`));
-        }
-      }
-
-      return callback(null, context);
-    },
-    function checkIfXPathIsUsed(context, callback) {
-      // FIXME: This should probably be in core.
-      let xmlInstalled = null;
-      try {
-        xmlInstalled = require('artillery-xml-capture');
-      } catch (e) {
-      }
-
-      let usesXPathCapture = false;
-      context.script.scenarios.forEach(function(scenario) {
-        scenario.flow.forEach(function(step) {
-          let params = step[_.keys(step)[0]];
-          if ((params.capture && params.capture.xpath) ||
-              (params.match && params.match.xpath)) {
-            usesXPathCapture = true;
-          }
-        });
-      });
-      if (usesXPathCapture && !xmlInstalled) {
-        console.log(chalk.bold.red('Warning: '), chalk.bold.yellow('your test script is using XPath capture, but artillery-xml-capture does not seem to be installed.'));
-        console.log(chalk.bold.yellow('Install it with: npm install -g artillery-xml-capture'));
-      }
-      return callback(null, context);
+    checkConfig,
+    readPayload
+  ], function done(err, script) {
+    if (err) {
+      console.log(err.message);
+      process.exit(1);
     }
-    ],
-    function(err, result) {
 
-      if (err) {
-        log(err.message);
-        process.exit(1);
-      }
+    script.config.statsInterval = script.config.statsInterval || 10;
 
-      if (options.insecure) {
-        if (result.script.config.tls) {
-          if (result.script.config.tls.rejectUnauthorized) {
-            log('WARNING: TLS certificate validation enabled in the ' +
-                        'test script, but explicitly disabled with ' +
-                        '-k/--insecure.');
-          }
-          result.script.config.tls.rejectUnauthorized = false;
-        } else {
-          result.script.config.tls = {rejectUnauthorized: false};
-        }
-      }
-
-      result.script.config.statsInterval = result.script.config.statsInterval || 10;
-
-      log('Log file: %s', logfile);
+    log('Log file: %s', logfile);
 
       var spinnerOn = function() {
         if (!options.quiet && process.stdout.isTTY) {
@@ -245,8 +87,8 @@ For more details see: https://github.com/nodejs/node/issues/9756
         }
       };
 
-      let runner = createRunner(result.script,
-                                result.payload,
+      let runner = createRunner(script,
+                                script.payload,
                                 {
                                   environment: options.environment,
                                   // This is used in the worker to resolve
@@ -270,7 +112,7 @@ For more details see: https://github.com/nodejs/node/issues/9756
         intermediates.push(report);
         spinnerOff();
         log('Report for the previous %ss @ %s',
-            result.script.config.statsInterval,
+            script.config.statsInterval,
             report.timestamp);
         if (!options.quiet) {
           printReport(report);
@@ -290,7 +132,7 @@ For more details see: https://github.com/nodejs/node/issues/9756
         if (!options.quiet) {
           printReport(report, { showScenarioCounts: true });
         }
-        report.phases = _.get(result, 'script.config.phases', []);
+        report.phases = _.get(script, 'config.phases', []);
         delete report.latencies;
 
         fs.writeFileSync(
@@ -300,9 +142,9 @@ For more details see: https://github.com/nodejs/node/issues/9756
           }, null, 2),
           {flag: 'w'});
 
-        if (result.script.config.ensure) {
+        if (script.config.ensure) {
           const latency = report.latency;
-          _.each(result.script.config.ensure, function(max, k) {
+          _.each(script.config.ensure, function(max, k) {
 
             let bucket = k === 'p50' ? 'median' : k;
             if (latency[bucket]) {
@@ -337,7 +179,7 @@ For more details see: https://github.com/nodejs/node/issues/9756
           process.exit(0);
         });
       }
-    });
+  });
 }
 
 function printReport(report, opts) {
@@ -400,4 +242,196 @@ function printReport(report, opts) {
       console.log('    %s: %s', code, count);
     });
   }
+}
+
+function readScript(scriptPath, callback) {
+  fs.readFile(scriptPath, 'utf-8', function(err, data) {
+    if (err) {
+      const msg = util.format('File not found: %s', scriptPath);
+      return callback(new Error(msg), null);
+    }
+
+    return callback(null, data, scriptPath);
+  });
+}
+
+function parseScript(data, scriptPath, callback) {
+  let script;
+  let fileFormat;
+
+  try {
+    if (/\.ya?ml$/.test(path.extname(scriptPath))) {
+      fileFormat = 'YAML';
+      script = YAML.load(data);
+    } else {
+      fileFormat = 'JSON';
+      script = JSON.parse(data);
+    }
+  } catch (e) {
+    const msg2 = `File ${scriptPath} does not appear to be valid ${fileFormat}: (${e.message})`;
+    return callback(new Error(msg2), null);
+  }
+
+  return callback(null, script);
+}
+
+function checkConfig(script, scriptPath, options, callback) {
+  if (options.environment) {
+    debug('environment specified: %s', options.environment);
+    if (script.config.environments[options.environment]) {
+      _.merge(script.config, script.config.environments[options.environment]);
+      debug(script.config.payload);
+    } else {
+      console.log(`WARNING: environment ${options.environment} is set but is not defined in the script`);
+    }
+  }
+
+  if (options.target && script.config) {
+    script.config.target = options.target;
+  }
+
+  if (!script.config.target && !options.environment) {
+    const msg4 = 'No target specified and no environment chosen';
+    return callback(new Error(msg4), null);
+  }
+
+  //
+  // Override/set config.tls if needed:
+  //
+  if (options.insecure) {
+    if (script.config.tls) {
+      if (script.config.tls.rejectUnauthorized) {
+        console.log('WARNING: TLS certificate validation enabled in the ' +
+                    'test script, but explicitly disabled with ' +
+                    '-k/--insecure.');
+      }
+      script.config.tls.rejectUnauthorized = false;
+    } else {
+      script.config.tls = {rejectUnauthorized: false};
+    }
+  }
+
+  //
+  // Turn config.payload into an array:
+  //
+  if (_.get(script, 'config.payload')) {
+    // Is it an object or an array?
+    if (_.isArray(script.config.payload)) {
+      // an array - nothing to do
+    } else if (_.isObject(script.config.payload)) {
+
+      if (options.payload && !_.get(script.config.payload, 'path')) {
+        script.config.payload.path = path.resolve(process.cwd(), options.payload);
+      } else if (!options.payload && !_.get(script.config.payload, 'path')) {
+        console.log('WARNING: config.payload.path not set and payload file not specified with -p');
+      } else if (options.payload && _.get(script.config.payload, 'path')) {
+        console.log('WARNING - both -p and config.payload.path are set, config.payload.path will be ignored.');
+        script.config.payload.path = options.payload;
+      } else {
+        // no -p but config.payload.path is set - nothing to do
+      }
+
+      // Make it an array
+      script.config.payload = [script.config.payload];
+    } else {
+      console.log('Ignoring config.payload, not an object or an array.');
+    }
+  }
+
+  //
+  // Resolve all payload paths to absolute paths now:
+  //
+  _.forEach(script.config.payload, function(payloadSpec) {
+    const absoluteScriptPath = path.resolve(process.cwd(), scriptPath);
+    const resolvedPathToPayload = path.resolve(
+      path.dirname(absoluteScriptPath), payloadSpec.path);
+    payloadSpec.path = resolvedPathToPayload;
+  });
+
+  return callback(null, script);
+}
+
+function validateSchema(script, callback) {
+  let validation = validate(script);
+  if (!validation.valid) {
+    console.log(validation.errors);
+    return callback(new Error('Test script validation error'));
+  }
+  return callback(null, script);
+}
+
+function readPayload(script, callback) {
+  async.map(
+    script.config.payload,
+    function readPayloadFile(payloadSpec, next) {
+      let data = fs.readFileSync(payloadSpec.path, 'utf-8');
+      csv(data, function(err, parsedData) {
+        payloadSpec.data = parsedData;
+        return next(err, payloadSpec);
+      });
+    },
+    function done(err, results) {
+      if (err) {
+        return callback(err, script);
+      }
+      script.payload = results;
+      return callback(null, script);
+    }
+  );
+}
+
+function checkTimersBug(script, callback) {
+  // Node.js versions 6.8.1 - 7.2.0 have a bug which can cause the process
+  // to hang when rampTo is used.
+  // Ref: https://github.com/shoreditch-ops/artillery/issues/210
+
+  // 6.8.1 and 7.0.0 and 7.2.0 but NOT 6.8.0
+  let nv = process.version;
+  let mj = parseInt(nv.substring(1, 2), 10);
+  let mn = parseInt(nv.substring(3, 4), 10);
+  let pt = parseInt(nv.substring(5, 6), 10);
+  if (mj === 7 && mn < 3 ||
+      (mj === 6 && mn > 8) ||
+      (mj === 6 && mn === 8 && pt > 0)) {
+    let usesRampTo = _.some(script.config.phases, function(phase) {
+      return !(_.isUndefined(phase.rampTo));
+    });
+
+    if (usesRampTo) {
+      console.error(chalk.bold.red(`
+You are running Node.js ${nv} which is affected by a bug that can cause
+Artillery to hang indefinitely when a rampTo arrival phase is used.
+
+Use Node.js v6.8.0 or lower to avoid the issue.
+
+For more details see: https://github.com/nodejs/node/issues/9756
+`));
+    }
+  }
+
+  return callback(null, script);
+}
+
+function checkIfXPathIsUsed(script, callback) {
+  let xmlInstalled = null;
+  try {
+    xmlInstalled = require('artillery-xml-capture');
+  } catch (e) {
+  }
+
+  let usesXPathCapture = false;
+  script.scenarios.forEach(function(scenario) {
+    scenario.flow.forEach(function(step) {
+      let params = step[_.keys(step)[0]];
+      if ((params.capture && params.capture.xpath) ||
+          (params.match && params.match.xpath)) {
+        usesXPathCapture = true;
+      }
+    });
+  });
+  if (usesXPathCapture && !xmlInstalled) {
+    console.log(chalk.bold.red('Warning: '), chalk.bold.yellow('your test script is using XPath capture, but artillery-xml-capture does not seem to be installed.'));
+    console.log(chalk.bold.yellow('Install it with: npm install -g artillery-xml-capture'));
+  }
+  return callback(null, script);
 }


### PR DESCRIPTION
- Refactor `run()` breaking it up into several smaller functions
- Handle `config.environments`