### PR TITLE
Cannot set v8debug in modern node

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -13,6 +13,7 @@ const os = require('os');
 const path = require('path');
 const EventEmitter = require('events');
 const fork = require('child_process').fork;
+const debugMode = require('debug-mode');
 
 const debug = require('debug')('artillery:runner');
 const L = require('lodash');
@@ -67,10 +68,10 @@ Runner.prototype.run = function run() {
     let forkOptions = {};
     // If running under a debugger, set non-clashing debugger ports for worker
     // processes.
-    // Run with: node --debug --expose_debug_as=v8debug --inspect
-    const debugging = (typeof v8debug === 'object');
+    // Run with: node --inspect
+    const debugging = debugMode();
     if (debugging) {
-      forkOptions.execArgv = [`--debug=${DEBUGGER_PORT + idx}`];
+      forkOptions.execArgv = [`--inspect=${DEBUGGER_PORT + idx}`];
     }
     let workerProcess = fork(path.join(__dirname, 'worker.js'), forkOptions);
     this._workers[workerProcess.pid] = {

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -65,15 +65,14 @@ Runner.prototype.run = function run() {
   //
   const DEBUGGER_PORT = 41986;
   L.each(workerScripts, (script, idx) => {
-    let forkOptions = {};
     // If running under a debugger, set non-clashing debugger ports for worker
     // processes.
     // Run with: node --inspect
     const debugging = debugMode();
     if (debugging) {
-      forkOptions.execArgv = [`--inspect=${DEBUGGER_PORT + idx}`];
+      process.execArgv.push([`--inspect=${DEBUGGER_PORT + idx}`]);
     }
-    let workerProcess = fork(path.join(__dirname, 'worker.js'), forkOptions);
+    let workerProcess = fork(path.join(__dirname, 'worker.js'));
     this._workers[workerProcess.pid] = {
       proc: workerProcess,
       isDone: false

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -64,11 +64,11 @@ Runner.prototype.run = function run() {
   // Create workers:
   //
   const DEBUGGER_PORT = 41986;
+  const debugging = debugMode();
   L.each(workerScripts, (script, idx) => {
     // If running under a debugger, set non-clashing debugger ports for worker
     // processes.
     // Run with: node --inspect
-    const debugging = debugMode();
     if (debugging) {
       process.execArgv.push([`--inspect=${DEBUGGER_PORT + idx}`]);
     }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "commander": "2.9.0",
     "csv-parse": "^0.1.1",
     "debug": "2.2.0",
+    "debug-mode": "^1.0.4",
     "lodash": "4.17.2",
     "moment": "2.11.2",
     "open": "0.0.5",


### PR DESCRIPTION
When trying to debug with the settings expected by the code one receives
`node: bad option: --expose_debug_as=v8debug`.

Without that option, v8debug will never be true, and the debugger will
never be attached to the child process.

I don't think this solution will be 'enough', as it uses the `--inspect` flag to start up the child process and that may not be backward compatible enough.

It also introduces another dependency, [debug-mode](https://www.npmjs.com/package/debug-mode) by IonicaBizau.

Fixes #337 