### PR TITLE
feat: Allow for options to be passed through via config.payload.options

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -332,7 +332,8 @@ function readPayload(script, callback) {
     script.config.payload,
     function readPayloadFile(payloadSpec, next) {
       let data = fs.readFileSync(payloadSpec.path, 'utf-8');
-      csv(data, function(err, parsedData) {
+      const csvOpts = payloadSpec.options || {};
+      csv(data, csvOpts, function(err, parsedData) {
         payloadSpec.data = parsedData;
         return next(err, payloadSpec);
       });

--- a/test/scripts/pets.txt
+++ b/test/scripts/pets.txt
@@ -1,0 +1,8 @@
+dog Leo
+dog Figo
+dog Mali
+cat Chewbacca
+cat Puss
+cat Bonnie
+cat Blanco
+pony Tiki

--- a/test/scripts/single_payload_options.json
+++ b/test/scripts/single_payload_options.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "target": "http://127.0.0.1:3003",
+    "phases": [
+      { "duration": 10, "arrivalRate": 5 }
+    ],
+    "payload": {
+      "path": "./pets.txt",
+      "fields": ["species", "name"],
+      "options": {
+        "delimiter": " "
+      }
+    }
+  },
+  "scenarios": [
+    {
+      "flow": [
+        {"get": {"url": "/{{{name}}}"}},
+        {"post": {"url": "/pets", "json": {"name": "{{ name }}", "species": "{{ species }}"}}}
+      ]
+    }
+  ]
+}

--- a/test/test.bats
+++ b/test/test.bats
@@ -68,6 +68,11 @@
   [ $? -eq 0 ]
 }
 
+@test "Run a script with one payload json config with parse options passed" {
+  ./bin/artillery run ./test/scripts/single_payload_options.json | grep 'All virtual users finished'
+  [ $? -eq 0 ]
+}
+
 @test "Run a script with multiple payloads" {
   ./bin/artillery run ./test/scripts/multiple_payloads.json | grep 'All virtual users finished'
   [ $? -eq 0 ]


### PR DESCRIPTION
NOTE: Re-opening after rebasing. Addresses feedback from other PR.

As some of our payload files contain data with commas, which are passed to the endpoint on the URL, this is an expedient way to make the payload processing in Artillery more flexible.

Verified this will work for us.

Thanks,

~Greg