### PR TITLE
feat: Allow for scenario variables to be passed in with "-v" option

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -17,7 +17,9 @@ const chalk = require('chalk');
 const debug = require('debug')('commands:run');
 const defaultOptions = require('rc')('artillery');
 const validate = require('../dispatcher').validate;
-const createRunner = process.env.MULTICORE ? require('../runner') : require('../runner-sp');
+const createRunner = process.env.MULTICORE
+  ? require('../runner')
+  : require('../runner-sp');
 const createConsoleReporter = require('../../console-reporter');
 
 const {
@@ -25,6 +27,7 @@ const {
   parseScript,
   prepareConfig,
   addOverrides,
+  addVariables,
   checkConfig
 } = require('../../util');
 
@@ -52,6 +55,10 @@ module.exports.getConfig = function(callback) {
         '--overrides <JSON>',
         'Object describing parts of the test script to override (experimental)'
       ],
+      [
+        '-v, --variables <definition>',
+        'Set variables for the test dynamically (comma-separated key=value pairs)'
+      ],
       ['-q, --quiet', 'Do not print anything to stdout']
     ]
   };
@@ -76,6 +83,7 @@ function run(scriptPath, options) {
       },
       prepareConfig,
       addOverrides,
+      addVariables,
       checkConfig,
       checkTimersBug,
       checkIfXPathIsUsed,

--- a/lib/util.js
+++ b/lib/util.js
@@ -12,6 +12,7 @@ module.exports = {
   parseScript,
   prepareConfig,
   addOverrides,
+  addVariables,
   checkConfig
 };
 
@@ -97,6 +98,29 @@ function addOverrides(script, scriptPath, options, callback) {
   return callback(null, script, scriptPath, options);
 }
 
+function addVariables(script, scriptPath, options, callback) {
+  if (options.variables) {
+    const rx = /^([A-Za-z_][\w\d]*=[\w\d]+)(,[A-Za-z_][\w\d]*=[\w\d]+)*$/;
+    if (!rx.test(options.variables)) {
+      return callback(
+        new Error(
+          'Variable definition is not valid. Correct example: "-v key1=value1,key2=value2"'
+        )
+      );
+    }
+
+    const pairs = options.variables.split(',');
+    if (!script.config.variables) {
+      script.config.variables = {};
+    }
+    pairs.forEach(pair => {
+      let [k, v] = pair.split('=');
+      script.config.variables[k] = v;
+    });
+  }
+  return callback(null, script, scriptPath, options);
+}
+
 function checkConfig(script, scriptPath, options, callback) {
   if (options.environment) {
     debug('environment specified: %s', options.environment);
@@ -105,7 +129,9 @@ function checkConfig(script, scriptPath, options, callback) {
       script._environment = options.environment;
     } else {
       console.log(
-        `WARNING: environment ${options.environment} is set but is not defined in the script`
+        `WARNING: environment ${
+          options.environment
+        } is set but is not defined in the script`
       );
     }
   }


### PR DESCRIPTION
Add "-v" option to "run" command to allow for scenario variables
to be set at run time, for example:

```
artillery run -v color=red,height=120 test.yaml
```

Makes variables "color" and "height" available in the script (with
the respective values of "red" and "120").