### PR TITLE
feat: Allow for scenario variables to be passed in with "-v" option

### DIFF
--- a/core/lib/engine_util.js
+++ b/core/lib/engine_util.js
@@ -213,6 +213,21 @@ function renderVariables (str, vars) {
   let rxmatch;
   let result = str.substring(0, str.length);
 
+
+  // Special case for handling integer/boolean/object substitution:
+  //
+  // Does the template string contain one variable and nothing else?
+  // e.g.: "{{ myvar }" or "{{    myvar }", but NOT " {{ myvar }"
+  // If so, we treat it as a special case.
+  const matches = str.match(RX);
+  if (matches && matches.length === 1) {
+    if (matches[0] === str) {
+      // there's nothing else in the template but the variable
+      const varName = str.replace(/{/g, '').replace(/}/g, '').trim();
+      return vars[varName] || '';
+    }
+  }
+
   while (result.search(RX) > -1) {
     let templateStr = result.match(RX)[0];
     const varName = templateStr.replace(/{/g, '').replace(/}/g, '').trim();

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -57,7 +57,7 @@ module.exports.getConfig = function(callback) {
       ],
       [
         '-v, --variables <definition>',
-        'Set variables for the test dynamically (comma-separated key=value pairs)'
+        'Set variables for the test dynamically (JSON object)'
       ],
       ['-q, --quiet', 'Do not print anything to stdout']
     ]

--- a/lib/util.js
+++ b/lib/util.js
@@ -100,22 +100,26 @@ function addOverrides(script, scriptPath, options, callback) {
 
 function addVariables(script, scriptPath, options, callback) {
   if (options.variables) {
-    const rx = /^([A-Za-z_][\w\d]*=[\w\d]+)(,[A-Za-z_][\w\d]*=[\w\d]+)*$/;
-    if (!rx.test(options.variables)) {
+    let variables = null;
+    try {
+      variables = JSON.parse(options.variables);
+    } catch (parseErr) {
+    }
+
+    if (!variables) {
       return callback(
         new Error(
-          'Variable definition is not valid. Correct example: "-v key1=value1,key2=value2"'
-        )
+          `Variable definition is not valid JSON. Correct example: -v '{"var1": "value1", "var2": "value2"}'`
+        ), script, scriptPath, options
       );
     }
 
-    const pairs = options.variables.split(',');
     if (!script.config.variables) {
       script.config.variables = {};
     }
-    pairs.forEach(pair => {
-      let [k, v] = pair.split('=');
-      script.config.variables[k] = v;
+
+    Object.keys(variables).forEach((varName) => {
+      script.config.variables[varName] = variables[varName];
     });
   }
   return callback(null, script, scriptPath, options);


### PR DESCRIPTION
Add "-v" option to "run" command to allow for scenario variables
to be set at run time using JSON, for example:

artillery run -v '{"color":"red", "height":120}' test.yaml

Makes variables "color" and "height" available in the script (with
the respective values of "red" and "120").