### PR TITLE
fix: Handle undefined argument to template()

### DIFF
--- a/core/lib/engine_util.js
+++ b/core/lib/engine_util.js
@@ -190,6 +190,11 @@ function isProbableEnough(obj) {
 
 function template(o, context) {
   let result;
+
+  if (typeof o === 'undefined') {
+    return undefined;
+  }
+
   if (o.constructor === Object) {
     result = traverse(o).map(function(x) {
 


### PR DESCRIPTION
The first argument to template() may be undefined if the calling
code passes in the result of reading a non-existing attribute on
an object like here:

https://github.com/shoreditch-ops/artillery/blob/715371ae517d728eca972a6220728359ca6a49ac/core/lib/engine_socketio.js#L234

Fixes https://github.com/shoreditch-ops/artillery/issues/495