### PR TITLE
Add whileTrue condition in WebSocket and Socket.io engines.

### DIFF
--- a/core/lib/engine_socketio.js
+++ b/core/lib/engine_socketio.js
@@ -130,7 +130,9 @@ SocketIoEngine.prototype.step = function (requestSpec, ee) {
       steps,
       {
         loopValue: requestSpec.loopValue,
-        overValues: requestSpec.over
+        overValues: requestSpec.over,
+        whileTrue: self.config.processor ?
+          self.config.processor[requestSpec.whileTrue] : undefined
       }
     );
   }

--- a/core/lib/engine_ws.js
+++ b/core/lib/engine_ws.js
@@ -42,7 +42,9 @@ WSEngine.prototype.step = function (requestSpec, ee) {
       steps,
       {
         loopValue: requestSpec.loopValue || '$loopCount',
-        overValues: requestSpec.over
+        overValues: requestSpec.over,
+        whileTrue: self.config.processor ?
+          self.config.processor[requestSpec.whileTrue] : undefined
       });
   }
 


### PR DESCRIPTION
Since the logic in actually handled by the `utils` engine, I've just added the `whileTrue` property in step definition.

Must fix #468.