### PR TITLE
Add option to exclude raw data from generated reports.

### DIFF
--- a/lib/commands/report.js
+++ b/lib/commands/report.js
@@ -17,7 +17,8 @@ module.exports.getConfig = function(callback) {
     command: 'report <file>',
     description: 'Create a report from a JSON file created by "artillery run"',
     options: [
-      ['-o, --output <path>', 'Set file to write html report to (will open in browser by default)']
+      ['-o, --output <path>', 'Set file to write html report to (will open in browser by default)'],
+      ['-e  --exclude-raw-data', 'Exclude the "Raw Report Data" section on report (can cause high CPU consumption on large data sets)']
     ]
   };
 
@@ -31,6 +32,7 @@ module.exports.getConfig = function(callback) {
 function report(jsonReportPath, options) {
 
   let reportFilename = options.output || jsonReportPath + '.html';
+  const excludeRawDataSection = options.excludeRawData;
 
   let data = JSON.parse(fs.readFileSync(jsonReportPath, 'utf-8'));
   let templateFn = path.join(
@@ -38,7 +40,12 @@ function report(jsonReportPath, options) {
     '../report/index.html.ejs');
   let template = fs.readFileSync(templateFn, 'utf-8');
   let compiledTemplate = l.template(template);
-  let html = compiledTemplate({report: JSON.stringify(data, null, 2)});
+
+  let html = compiledTemplate({
+    report: JSON.stringify(data, null, 2),
+    excludeRawDataSection
+  });
+
   fs.writeFileSync(
     reportFilename,
     html,

--- a/lib/report/index.html.ejs
+++ b/lib/report/index.html.ejs
@@ -15,7 +15,9 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.6/moment.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lodash.js/3.10.1/lodash.min.js"></script>
 
+  <% if (!excludeRawDataSection) { %>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.0/ace.js" charset="utf-8"></script>
+  <% } %>
 
   <style>
   body, p, li {
@@ -40,6 +42,7 @@
     margin-top: 1em;
     background-color: #eee;
   }
+
   #editor {
     font-size: 8pt;
     height: 20em;
@@ -217,6 +220,7 @@
 
 </div>
 
+<% if (!excludeRawDataSection) { %>
 <div class="row">
   <div class="col-lg-8 col-lg-offset-2">
     <h3 class="text-center">Raw report data</h3>
@@ -225,12 +229,16 @@
     </div>
   </div>
 </div>
+<% } %>
 
 <script>
+
+<% if (!excludeRawDataSection) { %>
 var editor = ace.edit("editor");
 editor.getSession().setMode("ace/mode/javascript");
 editor.setValue(JSON.stringify(Report, null, 2));
 editor.gotoLine(1);editor.setHighlightActiveLine(false);
+<% } %>
 
 var l = _;
 

--- a/test/testcases/command-report.bats
+++ b/test/testcases/command-report.bats
@@ -10,3 +10,17 @@
   [ $? -eq 0 ]
   [ -f $HTML_OUT ]
 }
+
+@test "If we report without specifying if we want the 'Raw Report Data' section, it is emitted by default in the output HTML" {
+  HTML_OUT="$(mktemp -d)/report.html"
+  ./bin/artillery report -o $HTML_OUT test/scripts/report.json
+  grep 'Raw report data' $HTML_OUT
+}
+
+@test "If we report specifying to exclude the 'Raw Report Data' section, it is not emitted in the output HTML" {
+  HTML_OUT="$(mktemp -d)/report.html"
+  ./bin/artillery report -e -o $HTML_OUT test/scripts/report.json
+  
+  run 'Raw report data' $HTML_OUT
+  [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
Add the “-e” option in the “report” command to exclude the “Raw Report Data” section from generated reports. Addresses #401