### PR TITLE
feat(run): Add config.ensure.maxErrorRate option

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -6,7 +6,6 @@
 
 const path = require('path');
 const fs = require('fs');
-const util = require('util');
 
 const _ = require('lodash');
 const async = require('async');
@@ -166,18 +165,24 @@ function run(scriptPath, options) {
             let bucket = k === 'p50' ? 'median' : k;
             if (latency[bucket]) {
               if (latency[bucket] > max) {
-                const msg = util.format(
-                  'ensure condition failed: ensure.%s < %s',
-                  bucket,
-                  max
-                );
                 if (!options.quiet) {
-                  console.log(msg);
+                  console.log(chalk.red(`ensure condition failed: ensure.${bucket} < ${max}`));
                 }
                 process.exit(1);
               }
             }
           });
+
+          if (typeof script.config.ensure.maxErrorRate !== 'undefined') {
+            const failRate = Math.round((report.scenariosCreated - report.scenariosCompleted) / report.scenariosCreated * 100);
+
+            if (failRate > script.config.ensure.maxErrorRate) {
+              if (!options.quiet) {
+                console.log(chalk.red(`ensure condition failed: ensure.maxErrorRate <= ${script.config.ensure.maxErrorRate}`));
+              }
+              process.exit(1);
+            }
+          }
         }
 
         gracefulShutdown();


### PR DESCRIPTION
Add `maxErrorRate` option to `config.ensure` to make Artillery exit with
a non-zero status code if the ratio of failed to successful scenarios
is higher than the value specified.

For example, exit with non-zero code if any errors occur:

```yaml
config:
  ensure:
    maxErrorRate: 0
scenarios:
  # scenario definitions
```

Both OS-level errors such as ECONNRESET, and errors returned from
hooks will be taken into account.