### PR TITLE
fix(util): Handle cases when the JSONPath expression is not valid

### DIFF
--- a/core/lib/engine_util.js
+++ b/core/lib/engine_util.js
@@ -474,7 +474,8 @@ function dummyParser(body, callback) {
 
 // doc is a JSON object
 function extractJSONPath(doc, expr) {
-  if (typeof doc !== 'object') {
+  // typeof null is 'object' hence the explicit check here
+  if (typeof doc !== 'object' || doc === null) {
     return '';
   }
 

--- a/core/lib/engine_util.js
+++ b/core/lib/engine_util.js
@@ -478,7 +478,13 @@ function extractJSONPath(doc, expr) {
     return '';
   }
 
-  let results = jsonpath.query(doc, expr);
+  let results;
+
+  try {
+    results = jsonpath.query(doc, expr);
+  } catch (queryErr) {
+    debug(queryErr);
+  }
 
   if (!results) {
     return '';


### PR DESCRIPTION
Fixes https://github.com/shoreditch-ops/artillery/issues/549

Extractors will need to be refactored to allow for an error to be returned (and subsequently made visible to the user). Failing silently and returning an empty string when the JSONPath expression is invalid is not ideal.