### PR TITLE
Allows skipping of request in beforeRequest - #564

### DIFF
--- a/core/lib/engine_http.js
+++ b/core/lib/engine_http.js
@@ -189,12 +189,12 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
       let cond;
       let result;
       try {
-        cond = filtrex(params.ifTrue);
+        cond = _.has(config.processor, params.ifTrue) ?  config.processor[params.ifTrue]  : filtrex(params.ifTrue);
         result = cond(context.vars);
       } catch (e) {
         result = 1; // if the expression is incorrect, just proceed // TODO: debug message
       }
-      if (typeof result === 'undefined' || result === 0) {
+      if (!result) {
         return process.nextTick(function () {
           callback(null, context);
         });
@@ -233,11 +233,6 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
           let errCode = err.code || err.message;
           // FIXME: Should not need to have to emit manually here
           ee.emit('error', errCode);
-          if (err.ignore) {
-            return process.nextTick(function () {
-              callback(null, context);
-            });
-          }
           return callback(err, context);
         }
 

--- a/core/lib/engine_http.js
+++ b/core/lib/engine_http.js
@@ -233,6 +233,11 @@ HttpEngine.prototype.step = function step(requestSpec, ee, opts) {
           let errCode = err.code || err.message;
           // FIXME: Should not need to have to emit manually here
           ee.emit('error', errCode);
+          if (err.ignore) {
+            return process.nextTick(function () {
+              callback(null, context);
+            });
+          }
           return callback(err, context);
         }
 


### PR DESCRIPTION
Added a check in Artillery HTTP Engine to check for ignore value
If the check is true, then Artillery will proceed with next request
This allows invalid requests to be skipped rather than exit scenario