### PR TITLE
feat: Add extra options for config.payload

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -246,7 +246,14 @@ function readPayload(script, callback) {
     script.config.payload,
     function readPayloadFile(payloadSpec, next) {
       let data = fs.readFileSync(payloadSpec.path, 'utf-8');
-      const csvOpts = payloadSpec.options || {};
+      let csvOpts = {
+        skip_empty_lines: typeof payloadSpec.skipEmptyLines === 'undefined' ? true : payloadSpec.skipEmptyLines,
+        cast: typeof payloadSpec.cast === 'undefined' ? true : payloadSpec.cast,
+        from_line: typeof payloadSpec.skipHeader === true ? 1 : 0,
+        delimiter: payloadSpec.delimiter || ','
+      };
+      // Defaults may still be overridden:
+      csvOpts = Object.assign(csvOpts, payloadSpec.options);
       csv(data, csvOpts, function(err, parsedData) {
         payloadSpec.data = parsedData;
         return next(err, payloadSpec);

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "chalk": "1.1.3",
     "cheerio": "^1.0.0-rc.2",
     "commander": "2.9.0",
-    "csv-parse": "^0.1.4",
+    "csv-parse": "^4.0.1",
     "debug": "^2.2.0",
     "deep-equal": "^1.0.1",
     "driftless": "^2.0.3",


### PR DESCRIPTION
Add `skipEmptyLines`, `cast`, `skipHeaders` and `delimiter` options.

- `skipEmptyLines` (default `true`) -- skip any empty lines in the CSV file
- `cast` (default `true`) -- convert values to native types (e.g. numbers)
- `skipHeader` (default `false`) -- skip the header row when populating variables
- `delimiter` (default `,`) -- set the delimiter