### PR TITLE
Make template() available externally

### DIFF
--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -5,5 +5,21 @@
 'use strict';
 
 const core = require('../core');
+const version = require('../package.json').version;
+
+function createGlobalObject(opts) {
+  if (typeof global.artillery !== 'undefined') {
+    return;
+  }
+
+  global.artillery = {
+    version: version,
+    util: {
+      template: require('../util').template
+    }
+  };
+}
+
+createGlobalObject();
 
 module.exports = core;

--- a/lib/util.js
+++ b/lib/util.js
@@ -9,6 +9,8 @@ const _ = require('lodash');
 
 const engineUtil = require('../core/lib/engine_util');
 const renderVariables = engineUtil._renderVariables;
+const template = engineUtil.template;
+
 
 module.exports = {
   readScript,
@@ -17,7 +19,8 @@ module.exports = {
   addOverrides,
   addVariables,
   checkConfig,
-  renderVariables
+  renderVariables,
+  template
 };
 
 function readScript(scriptPath, callback) {

--- a/test/scripts/hello.json
+++ b/test/scripts/hello.json
@@ -3,6 +3,7 @@
     {
       "beforeRequest": ["printHello"],
       "flow": [
+        {"function": "checkGlobal"},
         {"get": {"url": "/"}},
         {"post": {"url": "/pets", "json": {"name": "Figo", "species": "dog"}}},
         {"loop": [
@@ -10,7 +11,7 @@
             {"log": "outer: {{ $loopCount }}; inner: {{ k }}"}
           ], "count": "5", "loopValue": "k"}
         ], "count": 3},
-        {"get": "/does/not/exist", "beforeRequest": "rewriteUrl"}
+        {"get": {"url": "/does/not/exist", "beforeRequest": "rewriteUrl"}}
       ]
     }
   ]

--- a/test/scripts/processor.js
+++ b/test/scripts/processor.js
@@ -3,7 +3,8 @@
 module.exports = {
   printHello: printHello,
   createNewVar: createNewVar,
-  rewriteUrl: rewriteUrl
+  rewriteUrl: rewriteUrl,
+  checkGlobal: checkGlobal
 };
 
 function printHello(req, ctx, events, done) {
@@ -29,3 +30,12 @@ function rewriteUrl(req, ctx, events, done) {
   req.url = '/';
   return done();
 }
+
+function checkGlobal(ctx, events, done) {
+  if (!global.artillery) {
+    return done(new Error('global artillery object not found'));
+  } else {
+    console.log(`[${process.pid}] artillery.version: ${artillery.version}`);
+    return done();
+  }
+};


### PR DESCRIPTION
1. Export `template()` from `artillery/utils`
2. Experimental: create a global `artillery` object to be used by plugins, custom JS code, and engines.