### PR TITLE
feat: Allow for payload path to be templated

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -134,7 +134,8 @@ function addVariables(script, scriptPath, options, callback) {
     script.config,
     { vars:
       {
-        $processEnvironment: process.env
+        $processEnvironment: process.env,
+        $environment: options.environment
       }
     });
 
@@ -142,11 +143,12 @@ function addVariables(script, scriptPath, options, callback) {
 }
 
 function checkConfig(script, scriptPath, options, callback) {
+  script._environment = options.environment;
+
   if (options.environment) {
     debug('environment specified: %s', options.environment);
-    if (script.config.environments[options.environment]) {
+    if (script.config.environments && script.config.environments[options.environment]) {
       _.merge(script.config, script.config.environments[options.environment]);
-      script._environment = options.environment;
     } else {
       console.log(
         `WARNING: environment ${

--- a/test/scripts/local-urls.csv
+++ b/test/scripts/local-urls.csv
@@ -1,0 +1,7 @@
+/pets
+/pets
+/pets
+/pets
+/pets
+/pets
+/pets

--- a/test/scripts/multiple_payloads.json
+++ b/test/scripts/multiple_payloads.json
@@ -12,6 +12,10 @@
         {
           "path": "./urls.csv",
           "fields": ["url"]
+        },
+        {
+          "path": "./{{$environment}}-urls.csv",
+          "fields": ["url"]
         }
       ]
   },

--- a/test/testcases/command-run.bats
+++ b/test/testcases/command-run.bats
@@ -39,8 +39,8 @@
   [ $? -eq 0 ]
 }
 
-@test "Run a script with multiple payloads" {
-  ./bin/artillery run ./test/scripts/multiple_payloads.json | grep 'All virtual users finished'
+@test "Run a script with multiple payloads and use of $environment in path" {
+  ./bin/artillery run -e local ./test/scripts/multiple_payloads.json | grep 'All virtual users finished'
   [ $? -eq 0 ]
 }
 


### PR DESCRIPTION
Payload `path` field may be templated, with access to
- $environment -- containing the name of the environment (if set)
- $processEnvironment -- containing the process environment vars

Ref: https://github.com/shoreditch-ops/artillery/issues/505